### PR TITLE
feat: Integrate OpenZeppelin Contracts and Configure Foundry

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "lib/openzeppelin-contracts"]
+	path = lib/openzeppelin-contracts
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts

--- a/foundry.lock
+++ b/foundry.lock
@@ -4,5 +4,11 @@
       "name": "v1.11.0",
       "rev": "8e40513d678f392f398620b3ef2b418648b33e89"
     }
+  },
+  "lib/openzeppelin-contracts": {
+    "tag": {
+      "name": "v5.4.0",
+      "rev": "c64a1edb67b6e3f4a15cca8909c9482ad33a02b0"
+    }
   }
 }

--- a/foundry.toml
+++ b/foundry.toml
@@ -6,4 +6,9 @@ solc = "0.8.26"
 auto_detect_solc = true
 via_ir = true
 
+remappings = [
+    "forge-std/=lib/forge-std/src/",
+    "@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/",
+]
+
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/foundry.toml
+++ b/foundry.toml
@@ -2,5 +2,8 @@
 src = "src"
 out = "out"
 libs = ["lib"]
+solc = "0.8.26"
+auto_detect_solc = true
+via_ir = true
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options


### PR DESCRIPTION
This PR introduces the **OpenZeppelin Contracts** library as a submodule and updates the **Foundry** configuration to support its usage.

## Changes:

* **Installs OpenZeppelin Contracts:** Adds `openzeppelin-contracts` as a git submodule to `lib/` and updates `foundry.lock`.
    * *Commit:* `feat: Install Openzeppelin Contracts Library`
* **Adds Remappings:** Configures the necessary remapping in `foundry.toml` to allow importing OpenZeppelin contracts using the standard `@openzeppelin/contracts/` path.
    * *Commit:* `feat: Add Remappings To foundry.toml`
* **Updates `foundry.toml`:** A commit is listed to update `profile.default foundry.toml`, likely to include the remappings and other standard configuration like `via_ir = true`.
    * *Commit:* `feat: Update profile.default foundry.toml`

## File Changes Overview:

* `.gitmodules`: Adds the submodule entry for `lib/openzeppelin-contracts`.
* `foundry.lock`: Records the dependency version for `lib/openzeppelin-contracts` (v5.4.0).
* `foundry.toml`: Includes the remapping:
    ```toml
    remappings = [
        "forge-std/=lib/forge-std/src/",
        "@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/",
    ]
    ```

This setup is crucial for developing secure and standardized smart contracts using commonly accepted libraries.