### PR TITLE
feat: Add Color and Background Mappings for Dynamic Metadata Rendering

### DIFF
--- a/src/V1/MetadataRenderer.sol
+++ b/src/V1/MetadataRenderer.sol
@@ -16,4 +16,5 @@ contract MetadataRenderer is IMetadataRenderer, Ownable {
         // Color schemes for different weather conditions
     mapping(string => string) public weatherColors;
         mapping(string => string) public timeColors;
+        mapping(string => string) public weatherBackgrounds;
 }

--- a/src/V1/MetadataRenderer.sol
+++ b/src/V1/MetadataRenderer.sol
@@ -15,4 +15,5 @@ contract MetadataRenderer is IMetadataRenderer, Ownable {
 
         // Color schemes for different weather conditions
     mapping(string => string) public weatherColors;
+        mapping(string => string) public timeColors;
 }

--- a/src/V1/MetadataRenderer.sol
+++ b/src/V1/MetadataRenderer.sol
@@ -12,4 +12,7 @@ import "../interfaces/IMetadataRenderer.sol";
  */
 contract MetadataRenderer is IMetadataRenderer, Ownable {
     using Strings for uint256;
+
+        // Color schemes for different weather conditions
+    mapping(string => string) public weatherColors;
 }

--- a/src/V1/MetadataRenderer.sol
+++ b/src/V1/MetadataRenderer.sol
@@ -13,8 +13,8 @@ import "../interfaces/IMetadataRenderer.sol";
 contract MetadataRenderer is IMetadataRenderer, Ownable {
     using Strings for uint256;
 
-        // Color schemes for different weather conditions
+    // Color schemes for different weather conditions
     mapping(string => string) public weatherColors;
-        mapping(string => string) public timeColors;
-        mapping(string => string) public weatherBackgrounds;
+    mapping(string => string) public timeColors;
+    mapping(string => string) public weatherBackgrounds;
 }


### PR DESCRIPTION
# PR Description

## Summary

This pull request introduces three public state variables as `mapping(string => string)` to the `MetadataRenderer.sol` contract. These mappings are intended to store configurable color and background schemes based on specific attributes, likely **weather** and **time**, for dynamic NFT metadata generation.

This is a preparatory step to allow the rendering logic to select appropriate visual styles based on the token's current state.

## Commits Included

-   `feat: Add weatherColors Mapping`
-   `feat: Add timeColors Mapping`
-   `feat: Add weatherBackgrounds Mapping`
-   `feat: forge fmt`

## Changes in `src/V1/MetadataRenderer.sol`

The main changes are the addition of three mapping declarations within the `MetadataRenderer` contract:

```solidity
@@ -12,4 +12,9 @@
 import "../interfaces/IMetadataRenderer.sol";
 */
 contract MetadataRenderer is IMetadataRenderer, Ownable {
     using Strings for uint256;

     // Color schemes for different weather conditions
     mapping(string => string) public weatherColors;
     mapping(string => string) public timeColors;
     mapping(string => string) public weatherBackgrounds;
 }