### PR TITLE
feat: Initialize MetadataRenderer and Refactor Front-end Context

### DIFF
--- a/frontend/one-of-one-nfts/src/app/layout.tsx
+++ b/frontend/one-of-one-nfts/src/app/layout.tsx
@@ -1,7 +1,4 @@
 import type { Metadata } from "next";
-
-
-import { headers } from 'next/headers' // added
 import './globals.css';
 import ContextProvider from '@/context'
 
@@ -10,18 +7,15 @@ export const metadata: Metadata = {
   description: "one of one nft mints",
 };
 
-export default async function RootLayout({
+export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const headersData = await headers();
-  const cookies = headersData.get('cookie');
-
   return (
     <html lang="en">
       <body>
-        <ContextProvider cookies={cookies}>{children}</ContextProvider>
+        <ContextProvider cookies={null}>{children}</ContextProvider>
       </body>
     </html>
   );

--- a/frontend/one-of-one-nfts/src/context/index.tsx
+++ b/frontend/one-of-one-nfts/src/context/index.tsx
@@ -13,7 +13,7 @@ const queryClient = new QueryClient()
 const metadata = {
   name: 'one-of-one-nfts',
   description: 'one of one nft mints',
-  url: 'https://github.com/0xonerb/next-reown-appkit-ssr', // origin must match your domain & subdomain
+  url: 'https://andrewsing1.github.io/one-of-ones-nfts', // Updated to your GitHub Pages URL
   icons: ['https://avatars.githubusercontent.com/u/179229932']
 }
 
@@ -33,7 +33,9 @@ export const modal = createAppKit({
 })
 
 function ContextProvider({ children, cookies }: { children: ReactNode; cookies: string | null }) {
-  const initialState = cookieToInitialState(wagmiAdapter.wagmiConfig as Config, cookies)
+  // For static export, cookies will always be null, so initialState will be undefined
+  // This is fine - Wagmi will initialize from client-side storage instead
+  const initialState = cookies ? cookieToInitialState(wagmiAdapter.wagmiConfig as Config, cookies) : undefined
 
   return (
     <WagmiProvider config={wagmiAdapter.wagmiConfig as Config} initialState={initialState}>

--- a/src/V1/MetadataRenderer.sol
+++ b/src/V1/MetadataRenderer.sol
@@ -10,7 +10,7 @@ import "../interfaces/IMetadataRenderer.sol";
  * @title MetadataRenderer
  * @dev Generates dynamic metadata and SVG images for NFTs based on their state
  */
-contract MetadataRenderer is IMetadataRenderer, Ownable {
+contract MetadataRenderer is Ownable {
     using Strings for uint256;
 
     // Color schemes for different weather conditions
@@ -20,5 +20,32 @@ contract MetadataRenderer is IMetadataRenderer, Ownable {
 
     constructor() Ownable(msg.sender) {
         _initializeColorSchemes();
+    }
+
+    /**
+     * @dev Initialize color schemes for weather and time
+     */
+    function _initializeColorSchemes() internal {
+        // Weather colors
+        weatherColors["sunny"] = "#FFD700";
+        weatherColors["cloudy"] = "#87CEEB";
+        weatherColors["rainy"] = "#4682B4";
+        weatherColors["stormy"] = "#2F4F4F";
+        weatherColors["snowy"] = "#F0F8FF";
+        weatherColors["foggy"] = "#D3D3D3";
+
+        // Time of day colors
+        timeColors["morning"] = "#FFA07A";
+        timeColors["afternoon"] = "#87CEFA";
+        timeColors["evening"] = "#DDA0DD";
+        timeColors["night"] = "#191970";
+
+        // Weather backgrounds
+        weatherBackgrounds["sunny"] = "linear-gradient(45deg, #FFD700, #FFA500)";
+        weatherBackgrounds["cloudy"] = "linear-gradient(45deg, #87CEEB, #B0C4DE)";
+        weatherBackgrounds["rainy"] = "linear-gradient(45deg, #4682B4, #5F9EA0)";
+        weatherBackgrounds["stormy"] = "linear-gradient(45deg, #2F4F4F, #696969)";
+        weatherBackgrounds["snowy"] = "linear-gradient(45deg, #F0F8FF, #E6E6FA)";
+        weatherBackgrounds["foggy"] = "linear-gradient(45deg, #D3D3D3, #C0C0C0)";
     }
 }

--- a/src/V1/MetadataRenderer.sol
+++ b/src/V1/MetadataRenderer.sol
@@ -17,4 +17,8 @@ contract MetadataRenderer is IMetadataRenderer, Ownable {
     mapping(string => string) public weatherColors;
     mapping(string => string) public timeColors;
     mapping(string => string) public weatherBackgrounds;
+
+    constructor() Ownable(msg.sender) {
+        _initializeColorSchemes();
+    }
 }


### PR DESCRIPTION
Summary of Changes
This PR introduces critical structural updates on both the blockchain and front-end sides of the project.

On the smart contract side, the core MetadataRenderer contract is initialized with key properties, laying the groundwork for dynamic NFT attributes based on time and weather. On the front-end, the Next.js application structure is simplified by removing Server-Side Rendering (SSR) reliance on cookie headers for initial state, making the application more robust for static export and client-side authentication handling.

Backend Changes (src/V1/MetadataRenderer.sol)
The MetadataRenderer.sol contract now features a foundational structure for dynamic metadata generation:

Ownership Implementation: The contract now inherits from Ownable, giving administrative control (currently the deployer) over potential configuration functions in the future.

Initialization Logic: A constructor is implemented to call _initializeColorSchemes().

Dynamic Data Foundation: Mappings (weatherColors, timeColors, weatherBackgrounds) are initialized with detailed color/gradient schemes. This is the core logic that will be used later to generate the dynamic SVG based on off-chain data (weather, time of day).

Cleanup: The commit includes forge fmt for code styling consistency.

Interface Adjustment: Removed the import for IMetadataRenderer to streamline the contract during this foundational stage.

Front-end Changes (frontend/one-of-one-nfts/src/app/layout.tsx & .../src/context/index.tsx)
The UI refactoring focuses on simplifying state management and deployment architecture:

SSR Removal: The RootLayout component was converted from an async function back to a standard component. This removes the reliance on reading headers (cookies) for SSR initial state, simplifying the component structure significantly.

Context Simplification: The ContextProvider logic was simplified to only initialize state based on client-side context (if cookies are present), and gracefully fall back to undefined for client-side hydration, which improves compatibility with static export workflows (like GitHub Pages).

Metadata Update: The project's public URL in the context metadata was updated to https://andrewsing1.github.io/one-of-ones-nfts, reflecting the new GitHub Pages deployment target.

Checklist
[x] Implemented Ownable pattern in MetadataRenderer.sol.

[x] Added initialization logic for color schemes in the smart contract.

[x] Converted Next.js RootLayout from async to synchronous function.

[x] Simplified Wagmi/context initialization logic for client-side reliance.

[x] Code formatted using forge fmt.