### PR TITLE
feat: Add Owner-Controlled Functions to Dynamically Update SVG Color Schemes

### DIFF
--- a/src/V1/MetadataRenderer.sol
+++ b/src/V1/MetadataRenderer.sol
@@ -233,4 +233,8 @@ contract MetadataRenderer is IMetadataRenderer, Ownable {
     function updateTimeColor(string calldata timeOfDay, string calldata color) external onlyOwner {
         timeColors[timeOfDay] = color;
     }
+
+        function updateWeatherBackground(string calldata weather, string calldata background) external onlyOwner {
+        weatherBackgrounds[weather] = background;
+    }
 }

--- a/src/V1/MetadataRenderer.sol
+++ b/src/V1/MetadataRenderer.sol
@@ -229,4 +229,8 @@ contract MetadataRenderer is IMetadataRenderer, Ownable {
     function updateWeatherColor(string calldata weather, string calldata color) external onlyOwner {
         weatherColors[weather] = color;
     }
+
+    function updateTimeColor(string calldata timeOfDay, string calldata color) external onlyOwner {
+        timeColors[timeOfDay] = color;
+    }
 }

--- a/src/V1/MetadataRenderer.sol
+++ b/src/V1/MetadataRenderer.sol
@@ -222,4 +222,11 @@ contract MetadataRenderer is IMetadataRenderer, Ownable {
             )
         );
     }
+
+        /**
+     * @dev Update color scheme (only owner)
+     */
+    function updateWeatherColor(string calldata weather, string calldata color) external onlyOwner {
+        weatherColors[weather] = color;
+    }
 }

--- a/src/V1/MetadataRenderer.sol
+++ b/src/V1/MetadataRenderer.sol
@@ -223,7 +223,7 @@ contract MetadataRenderer is IMetadataRenderer, Ownable {
         );
     }
 
-        /**
+    /**
      * @dev Update color scheme (only owner)
      */
     function updateWeatherColor(string calldata weather, string calldata color) external onlyOwner {
@@ -234,7 +234,7 @@ contract MetadataRenderer is IMetadataRenderer, Ownable {
         timeColors[timeOfDay] = color;
     }
 
-        function updateWeatherBackground(string calldata weather, string calldata background) external onlyOwner {
+    function updateWeatherBackground(string calldata weather, string calldata background) external onlyOwner {
         weatherBackgrounds[weather] = background;
     }
 }


### PR DESCRIPTION
###  Overview

This pull request introduces three new **external, owner-restricted** functions to the `MetadataRenderer.sol` contract. These functions allow the contract owner to update the color mappings used for dynamic SVG generation without needing to deploy a new contract version. This provides essential administrative flexibility for maintaining and styling the dynamic NFT metadata.

### ⛓️ Smart Contract Changes (`src/V1/MetadataRenderer.sol`)

The following **admin functions**, protected by the `onlyOwner` modifier (inherited from `Ownable`), are added:

* **`updateWeatherColor(string calldata weather, string calldata color)`**:
    * Allows the owner to update the `weatherColors` mapping, changing the primary color associated with a specific weather condition.
* **`updateTimeColor(string calldata timeOfDay, string calldata color)`**:
    * Allows the owner to update the `timeColors` mapping, changing the color associated with a specific time of day.
* **`updateWeatherBackground(string calldata weather, string calldata background)`**:
    * Allows the owner to update the `weatherBackgrounds` mapping, changing the background gradient or color associated with a specific weather condition.

### ⚙️ Other Changes

* `forge fmt` was run to ensure final code formatting consistency.

### 🧪 Testing

* Verify that these functions can only be called by the contract owner.
* Test calling these functions with new color values (e.g., setting a new hex code for "sunny") and confirming that the subsequent `renderMetadata` output reflects the updated colors in the generated SVG.