### PR TITLE
feat: Define WeatherData struct and state variables (current data, updaters)

### DIFF
--- a/src/V1/WeatherOracle.sol
+++ b/src/V1/WeatherOracle.sol
@@ -11,6 +11,13 @@ import "../interfaces/IDataOracle.sol";
  * This is a mock implementation - in production you'd integrate with real weather APIs
  */
 contract WeatherOracle is IDataOracle, Ownable {
+        struct WeatherData {
+        string condition;
+        int256 temperature;
+        uint256 timestamp;
+        bool isValid;
+    }
+    
     constructor() Ownable(msg.sender) {
         // Initialize with default weather
         currentWeather = WeatherData({condition: "sunny", temperature: 22, timestamp: block.timestamp, isValid: true});

--- a/src/V1/WeatherOracle.sol
+++ b/src/V1/WeatherOracle.sol
@@ -11,19 +11,19 @@ import "../interfaces/IDataOracle.sol";
  * This is a mock implementation - in production you'd integrate with real weather APIs
  */
 contract WeatherOracle is IDataOracle, Ownable {
-        struct WeatherData {
+    struct WeatherData {
         string condition;
         int256 temperature;
         uint256 timestamp;
         bool isValid;
     }
 
-        // Current weather data
+    // Current weather data
     WeatherData public currentWeather;
 
-        // Authorized updaters (could be Chainlink nodes, API services, etc.)
+    // Authorized updaters (could be Chainlink nodes, API services, etc.)
     mapping(address => bool) public authorizedUpdaters;
-    
+
     constructor() Ownable(msg.sender) {
         // Initialize with default weather
         currentWeather = WeatherData({condition: "sunny", temperature: 22, timestamp: block.timestamp, isValid: true});

--- a/src/V1/WeatherOracle.sol
+++ b/src/V1/WeatherOracle.sol
@@ -17,6 +17,9 @@ contract WeatherOracle is IDataOracle, Ownable {
         uint256 timestamp;
         bool isValid;
     }
+
+        // Current weather data
+    WeatherData public currentWeather;
     
     constructor() Ownable(msg.sender) {
         // Initialize with default weather

--- a/src/V1/WeatherOracle.sol
+++ b/src/V1/WeatherOracle.sol
@@ -20,6 +20,9 @@ contract WeatherOracle is IDataOracle, Ownable {
 
         // Current weather data
     WeatherData public currentWeather;
+
+        // Authorized updaters (could be Chainlink nodes, API services, etc.)
+    mapping(address => bool) public authorizedUpdaters;
     
     constructor() Ownable(msg.sender) {
         // Initialize with default weather


### PR DESCRIPTION
### Summary 📦

This pull request completes the structural definition of the `WeatherOracle.sol` contract by adding the necessary **data structure (`WeatherData` struct)** and **state variables** required to store current data and manage update permissions.

### Key Changes and Rationale 📊

1.  **Added `WeatherData` Struct:**
    * A public `WeatherData` struct is defined to standardize how all weather information is stored on-chain. It includes:
        * `string condition`: e.g., "sunny", "rainy", "cloudy".
        * `int256 temperature`: Allows for storing temperatures below freezing.
        * `uint256 timestamp`: When the data was last recorded/updated.
        * `bool isValid`: Flag to indicate if the data is fresh and trustworthy.
2.  **Initialized Current Data Variable:**
    * A public state variable `currentWeather` of type `WeatherData` is added. This will hold the single, authoritative weather report used by the NFTs.
3.  **Added `authorizedUpdaters` Mapping:**
    * A public `mapping(address => bool) authorizedUpdaters` is introduced. This mapping is essential for controlling who has permission to call the data update functions (e.g., Chainlink nodes, authenticated API services).
4.  **Constructor Update (Implicit):**
    * The constructor is updated (or already implicitly defined in the previous PR) to initialize `currentWeather` with default values and set the deployer as the initial authorized updater.

These changes fully define the on-chain data model for the weather oracle.

### Files Changed 📁

* `src/V1/WeatherOracle.sol` (13 additions, 0 deletions)