### PR TITLE
feat: Add getData external view function to WeatherOracle

### DIFF
--- a/src/V1/WeatherOracle.sol
+++ b/src/V1/WeatherOracle.sol
@@ -60,6 +60,16 @@ contract WeatherOracle is Ownable {
         emit WeatherUpdated(condition, temperature, block.timestamp);
     }
 
+        /**
+     * @dev Get current weather data (implements IDataOracle)
+     */
+    function getData() external view returns (string memory) {
+        require(currentWeather.isValid, "No valid weather data");
+        require(block.timestamp <= currentWeather.timestamp + STALE_DATA_THRESHOLD, "Weather data is stale");
+
+        return currentWeather.condition;
+    }
+
     /**
      * @dev Check if weather condition is valid
      */

--- a/src/V1/WeatherOracle.sol
+++ b/src/V1/WeatherOracle.sol
@@ -60,7 +60,7 @@ contract WeatherOracle is Ownable {
         emit WeatherUpdated(condition, temperature, block.timestamp);
     }
 
-        /**
+    /**
      * @dev Get current weather data (implements IDataOracle)
      */
     function getData() external view returns (string memory) {


### PR DESCRIPTION
## :sparkles: Feature: Implement `getData()` for `WeatherOracle`

This PR introduces the `getData()` function to the `WeatherOracle.sol` contract, fulfilling the requirements of the `IDataOracle` interface.

### Key Changes:

* **Implement `getData()`:** A new `external view` function `getData()` is added.
    * It returns the current `condition` of the weather as a `string memory`.
    * It includes two crucial `require` checks:
        1.  Ensures that the `currentWeather` struct holds **valid data** (`currentWeather.isValid`).
        2.  Ensures that the data is **not stale** by checking that the current block timestamp is within the `STALE_DATA_THRESHOLD` of the data's timestamp.
* **Code Formatting:** Includes an automated commit to apply `forge fmt` for code style consistency.

### Associated Commits:

* `feat: Add getData External View Function`
* `feat: forge fmt`