### PR TITLE
feat: Add external view and updater functions to WeatherOracle

### DIFF
--- a/src/V1/WeatherOracle.sol
+++ b/src/V1/WeatherOracle.sol
@@ -95,7 +95,7 @@ contract WeatherOracle is Ownable {
 
         emit WeatherUpdated(condition, temperature, block.timestamp);
     }
-    
+
     /**
      * @dev Check if weather condition is valid
      */
@@ -106,5 +106,13 @@ contract WeatherOracle is Ownable {
             }
         }
         return false;
+    }
+
+        /**
+     * @dev Authorize/unauthorize updaters
+     */
+    function setAuthorizedUpdater(address updater, bool authorized) external onlyOwner {
+        authorizedUpdaters[updater] = authorized;
+        emit UpdaterAuthorized(updater, authorized);
     }
 }

--- a/src/V1/WeatherOracle.sol
+++ b/src/V1/WeatherOracle.sol
@@ -78,6 +78,25 @@ contract WeatherOracle is Ownable {
     }
 
     /**
+     * @dev Generate pseudo-random weather (for demo purposes)
+     */
+    function generateRandomWeather() external onlyAuthorizedUpdater {
+        uint256 randomIndex = uint256(keccak256(abi.encodePacked(block.timestamp, block.difficulty, msg.sender)))
+            % weatherConditions.length;
+
+        string memory condition = weatherConditions[randomIndex];
+
+        // Generate random temperature between -10 and 35 Celsius
+        int256 temperature =
+            int256((uint256(keccak256(abi.encodePacked(block.timestamp + 1, block.difficulty))) % 46)) - 10;
+
+        currentWeather =
+            WeatherData({condition: condition, temperature: temperature, timestamp: block.timestamp, isValid: true});
+
+        emit WeatherUpdated(condition, temperature, block.timestamp);
+    }
+    
+    /**
      * @dev Check if weather condition is valid
      */
     function _isValidWeatherCondition(string memory condition) internal view returns (bool) {

--- a/src/V1/WeatherOracle.sol
+++ b/src/V1/WeatherOracle.sol
@@ -70,6 +70,13 @@ contract WeatherOracle is Ownable {
         return currentWeather.condition;
     }
 
+        /**
+     * @dev Get detailed weather data
+     */
+    function getDetailedWeatherData() external view returns (WeatherData memory) {
+        return currentWeather;
+    }
+
     /**
      * @dev Check if weather condition is valid
      */

--- a/src/V1/WeatherOracle.sol
+++ b/src/V1/WeatherOracle.sol
@@ -70,7 +70,7 @@ contract WeatherOracle is Ownable {
         return currentWeather.condition;
     }
 
-        /**
+    /**
      * @dev Get detailed weather data
      */
     function getDetailedWeatherData() external view returns (WeatherData memory) {
@@ -108,7 +108,7 @@ contract WeatherOracle is Ownable {
         return false;
     }
 
-        /**
+    /**
      * @dev Authorize/unauthorize updaters
      */
     function setAuthorizedUpdater(address updater, bool authorized) external onlyOwner {


### PR DESCRIPTION
### PR Body

**What this PR introduces:**

This PR adds several new external functions to the `WeatherOracle` contract:

1.  **`getDetailedWeatherData()` (external view):** Allows users to retrieve the full `WeatherData` struct, including temperature, condition, and timestamp.
2.  **`generateRandomWeather()` (external):** A function intended for demonstration/testing purposes that generates and sets pseudo-random weather data. This function is restricted to be called only by **authorized updaters** via the `onlyAuthorizedUpdater` modifier.
3.  **`setAuthorizedUpdater(address updater, bool authorized)` (external):** An owner-only function that allows the contract **owner** to authorize or de-authorize specific addresses to call weather-setting functions (like `generateRandomWeather()`).

**Other changes:**

* Includes a `forge fmt` commit for consistent code formatting.